### PR TITLE
gRPC transport example

### DIFF
--- a/api/transport_grpc.go
+++ b/api/transport_grpc.go
@@ -1,0 +1,121 @@
+package api
+
+import (
+	"context"
+	"errors"
+
+	"github.com/go-kit/kit/endpoint"
+	"github.com/go-kit/kit/log"
+	grpctransport "github.com/go-kit/kit/transport/grpc"
+
+	account "github.com/marselester/ddd-err"
+	pb "github.com/marselester/ddd-err/rpc/account"
+)
+
+// NewGRPCUserServer makes user service available as a gRPC UserServer.
+func NewGRPCUserServer(s account.UserService, logger log.Logger) pb.UserServer {
+	options := []grpctransport.ServerOption{
+		grpctransport.ServerErrorLogger(logger),
+	}
+
+	srv := userServer{}
+	var ep endpoint.Endpoint
+	{
+		ep = makeFindUserByIDEndpoint(s)
+		srv.findUserByIDHandler = grpctransport.NewServer(
+			ep,
+			decodeGRPCfindUserByIDReq,
+			encodeGRPCfindUserByIDResp,
+			options...,
+		)
+	}
+	{
+		ep = makeCreateUserEndpoint(s)
+		srv.createUserHandler = grpctransport.NewServer(
+			ep,
+			decodeGRPCcreateUserReq,
+			encodeGRPCcreateUserResp,
+			options...,
+		)
+	}
+	return &srv
+}
+
+// userServer is gRPC server that implements protobuf UserServer interface.
+// It's like HTTP multiplexer.
+type userServer struct {
+	findUserByIDHandler grpctransport.Handler
+	createUserHandler   grpctransport.Handler
+}
+
+// FindUserByID looks up a user by ID.
+func (srv *userServer) FindUserByID(ctx context.Context, req *pb.FindUserByIDReq) (*pb.FindUserByIDResp, error) {
+	_, resp, err := srv.findUserByIDHandler.ServeGRPC(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*pb.FindUserByIDResp), nil
+}
+
+// CreateUser creates a user.
+func (srv *userServer) CreateUser(ctx context.Context, req *pb.CreateUserReq) (*pb.CreateUserResp, error) {
+	_, resp, err := srv.createUserHandler.ServeGRPC(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return resp.(*pb.CreateUserResp), nil
+}
+
+// decodeGRPCfindUserByIDReq is a transport/grpc.DecodeRequestFunc that converts a
+// gRPC FindUserByIDReq request to a user-domain FindUserByIDReq request.
+func decodeGRPCfindUserByIDReq(_ context.Context, grpcReq interface{}) (interface{}, error) {
+	req := grpcReq.(*pb.FindUserByIDReq)
+	return FindUserByIDReq{ID: req.Id}, nil
+}
+
+// encodeGRPCfindUserByIDResp is a transport/grpc.EncodeResponseFunc that converts a
+// user-domain FindUserByIDResp response to a gRPC FindUserByIDResp reply.
+func encodeGRPCfindUserByIDResp(_ context.Context, response interface{}) (interface{}, error) {
+	resp := response.(FindUserByIDResp)
+	return &pb.FindUserByIDResp{
+		Id:       resp.ID,
+		Username: resp.Username,
+		Error:    encodeGRPCerror(resp.Err),
+	}, nil
+}
+
+// decodeGRPCcreateUserReq is a transport/grpc.DecodeRequestFunc that converts a
+// gRPC CreateUserReq request to a user-domain CreateUserReq request.
+func decodeGRPCcreateUserReq(_ context.Context, grpcReq interface{}) (interface{}, error) {
+	req := grpcReq.(*pb.CreateUserReq)
+	return CreateUserReq{Username: req.Username}, nil
+}
+
+// encodeGRPCcreateUserResp is a transport/grpc.EncodeResponseFunc that converts a
+// user-domain CreateUserResp response to a gRPC CreateUserResp reply.
+func encodeGRPCcreateUserResp(_ context.Context, response interface{}) (interface{}, error) {
+	resp := response.(CreateUserResp)
+	return &pb.CreateUserResp{
+		Error: encodeGRPCerror(resp.Err),
+	}, nil
+}
+
+// encodeGRPCerror encodes domain error into gRPC error.
+func encodeGRPCerror(err error) *pb.Error {
+	if err == nil {
+		return nil
+	}
+
+	var accErr account.Error
+	if !errors.As(err, &accErr) {
+		accErr = account.Error{
+			Code:    account.EInternal,
+			Message: "An internal error has occurred.",
+		}
+	}
+
+	return &pb.Error{
+		Code:    accErr.Code,
+		Message: accErr.Message,
+	}
+}

--- a/docs/grpc.md
+++ b/docs/grpc.md
@@ -1,0 +1,103 @@
+# gRPC
+
+Similar to RESTful API based on Go kit, the service also supports gRPC transport.
+Have a look at [Go kit gRPC example](https://github.com/go-kit/kit/blob/master/examples/addsvc/pkg/addtransport/grpc.go).
+
+The protocol buffer definitions of User and Group services are described in `./rpc/account/account.proto`.
+You need to [install](https://grpc.io/docs/quickstart/go.html) protoc compiler and protoc plugin for Go
+
+```sh
+$ brew install protobuf
+$ go get -u github.com/golang/protobuf/protoc-gen-go
+```
+
+to generate gRPC service code. The arguments tell protoc to use `account.proto` definition,
+search for imports in `./rpc/account/` dir, generate Go code using gprc plugin,
+and place the result in `./rpc/account/` dir.
+
+```sh
+$ protoc account.proto -I rpc/account/ --go_out=plugins=grpc:rpc/account/
+```
+
+We now have newly generated gRPC server and client code in `./rpc/account/account.pb.go`.
+
+```
+$ go doc ./rpc/account/
+package account // import "github.com/marselester/ddd-err/rpc/account"
+
+func RegisterGroupServer(s *grpc.Server, srv GroupServer)
+func RegisterUserServer(s *grpc.Server, srv UserServer)
+type CreateGroupReq struct{ ... }
+type CreateGroupResp struct{ ... }
+type CreateUserReq struct{ ... }
+type CreateUserResp struct{ ... }
+type Error struct{ ... }
+type FindUserByIDReq struct{ ... }
+type FindUserByIDResp struct{ ... }
+type GroupClient interface{ ... }
+    func NewGroupClient(cc *grpc.ClientConn) GroupClient
+type GroupServer interface{ ... }
+type UnimplementedGroupServer struct{}
+type UnimplementedUserServer struct{}
+type UserClient interface{ ... }
+    func NewUserClient(cc *grpc.ClientConn) UserClient
+type UserServer interface{ ... }
+```
+
+## Convention
+
+The convention is inspired by [Twirp best practices](https://twitchtv.github.io/twirp/docs/best_practices.html).
+The `.proto` files should follow [Protocol Buffers style guide](https://developers.google.com/protocol-buffers/docs/style).
+
+```
+rpc/<domain_name>/<domain_name>.proto
+```
+
+For example, the domain package name of this project is `account`.
+It defines `UserService` and `GroupService` interfaces.
+
+```
+rpc/account/account.proto
+```
+
+If this project relied on another one (let's call it "authorization" project),
+then its `.proto` file should be copied to corresponding dir.
+
+```
+rpc/auth/auth.proto
+```
+
+- Use `package <repo_name>.<domain_name>;` for the package name.
+- Use `option go_package = "<domain_name>";` for the Go package name.
+
+## grpcurl
+
+[grpcurl](https://github.com/fullstorydev/grpcurl) is like cURL, but for gRPC.
+Install it from source
+
+```sh
+$ go get github.com/fullstorydev/grpcurl
+$ go install github.com/fullstorydev/grpcurl/cmd/grpcurl
+```
+
+and you're ready to send requests to the gRPC server. Note, your server must support
+[reflection](https://github.com/grpc/grpc-go/blob/master/Documentation/server-reflection-tutorial.md).
+
+```sh
+$ go run ./cmd/server/main.go
+$ grpcurl -plaintext localhost:8080 list
+ddd_err.account.User
+grpc.reflection.v1alpha.ServerReflection
+```
+
+Check if user with "123" ID exists
+
+```sh
+$ grpcurl -d '{"id": "123"}' -plaintext localhost:8080 ddd_err.account.User/FindUserByID
+{
+  "error": {
+    "message": "Invalid user ID.",
+    "code": "invalid_user_id"
+  }
+}
+```

--- a/rpc/account/account.proto
+++ b/rpc/account/account.proto
@@ -1,0 +1,43 @@
+syntax = "proto3";
+package ddd_err.account;
+option go_package = "account";
+
+service User {
+  rpc FindUserByID(FindUserByIDReq) returns (FindUserByIDResp);
+  rpc CreateUser(CreateUserReq) returns (CreateUserResp);
+}
+
+message FindUserByIDReq {
+  string id = 1;
+}
+
+message FindUserByIDResp {
+  string id = 1;
+  string username = 2;
+  Error error = 3;
+}
+
+message CreateUserReq {
+  string username = 1;
+}
+
+message CreateUserResp {
+  Error error = 1;
+}
+
+service Group {
+  rpc CreateGroup(CreateGroupReq) returns (CreateGroupResp);
+}
+
+message CreateGroupReq {
+  string name = 1;
+}
+
+message CreateGroupResp {
+  Error error = 1;
+}
+
+message Error {
+  string message = 1;
+  string code = 2;
+}

--- a/rpc/auth/auth.proto
+++ b/rpc/auth/auth.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+package ddd_auth.auth;
+option go_package = "auth";
+
+service Permission {
+  rpc ListPermissions(ListPermissionReq) returns (ListPermissionResp);
+}
+
+message ListPermissionReq {
+  string user_id = 1;
+}
+
+message ListPermissionResp {
+  message Permission {
+    string name = 1;
+    string codename = 2;
+  }
+  repeated Permission permissions = 1;
+  Error error = 2;
+}
+
+message Error {
+  string message = 1;
+  string code = 2;
+}


### PR DESCRIPTION
There are two popular approaches to organize proto files:
- create a dedicated repository for proto files
- keep them in service repositories

This gRPC example took [Twirp's approach](https://twitchtv.github.io/twirp/docs/best_practices.html) to keep the proto files in `rpc` folder.